### PR TITLE
use NameOID API to read CN, support intermediate certificate chain validation, support wildcard certificates

### DIFF
--- a/Custom Sensors/scripts/starttls_certificate.py
+++ b/Custom Sensors/scripts/starttls_certificate.py
@@ -29,6 +29,7 @@ import os
 import shlex
 import socket
 import ssl
+import _ssl
 import sys
 import certifi
 from cryptography import x509
@@ -144,7 +145,7 @@ def work(args: argparse.Namespace) -> dict:
         if args.sni_domain:
             server_hostname = args.sni_domain[0]
 
-        cert, conn = load_der_x509_certificate(conn, server_hostname)
+        cert, peer_intermediates, conn = load_der_x509_certificate(conn, server_hostname)
         disconnect(conn, args.protocol)
 
         if cert is None:
@@ -169,6 +170,7 @@ def work(args: argparse.Namespace) -> dict:
         result['message'] = ' - '.join(_message_parts)
         channels = validate_certificate(cert,
                                         server_hostname,
+                                        peer_chain=peer_intermediates,
                                         name_validation=name_validation,
                                         ca_trust=ca_trust,
                                         system_ca_trust=args.system_ca_trust)
@@ -236,15 +238,20 @@ def connect(host: str, port: int, protocol: str) -> socket.socket:
     return s
 
 def load_der_x509_certificate(connection: socket.socket,
-                              sni_domain: str) -> tuple[x509.Certificate | None, ssl.SSLSocket]:
-    """Reads the peer's binary certificate data and returns certificate and SSLSocket.
+                              sni_domain: str
+    ) -> tuple[x509.Certificate | None, list[x509.Certificate], ssl.SSLSocket]:
+    """Reads the peer's binary certificate data and returns certificate, intermediates, and SSLSocket.
+
+    Extracts the full certificate chain sent by the server during the TLS handshake.
+    The first certificate (leaf) is returned separately, remaining certificates are
+    returned as a list of intermediate certificates for chain building.
 
     :param connection: Connection with STARTTLS prepared and ready to communicate encrypted.
     :type connection: ssl.SSLSocket
     :param sni_domain: Server hostname if the device has multiple certificates on the same IP address.
     :type sni_domain: str
-    :return: Tuple of certificate or None and the prepared SSL socket.
-    :rtype: tuple[x509.Certificate | None, ssl.SSLSocket]
+    :return: Tuple of leaf certificate (or None), list of intermediate certificates, and SSL socket.
+    :rtype: tuple[x509.Certificate | None, list[x509.Certificate], ssl.SSLSocket]
     """
 
     # Create a custom context based on TLS_CLIENT
@@ -252,15 +259,28 @@ def load_der_x509_certificate(connection: socket.socket,
     ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
     ctx.check_hostname = False
     ctx.verify_mode = ssl.CERT_NONE
+    peer_intermediates = []
     try:
         sslsocket = ctx.wrap_socket(connection, server_hostname=sni_domain)
         cert_der_data = sslsocket.getpeercert(binary_form=True)
         if cert_der_data is None:
             raise ValueError(f'Host "{sni_domain}" did not provide certificate.')
         cert = x509.load_der_x509_certificate(cert_der_data)
+        # Extract intermediate certificates from the TLS handshake chain
+        # get_unverified_chain() returns the full chain as sent by the server:
+        # index 0 is the leaf, index 1..n are intermediates
+        try:
+            chain = sslsocket._sslobj.get_unverified_chain()
+            if chain and len(chain) > 1:
+                for chain_cert in chain[1:]:
+                    peer_intermediates.append(
+                        x509.load_der_x509_certificate(
+                            chain_cert.public_bytes(_ssl.ENCODING_DER)))
+        except AttributeError:
+            pass
     except ssl.SSLError | ValueError:
         cert = None
-    return cert, sslsocket
+    return cert, peer_intermediates, sslsocket
 
 def disconnect(connection: ssl.SSLSocket, protocol: str) -> None:
     """Closes an established connection (socket) with the proper protocol commands.
@@ -281,6 +301,7 @@ def disconnect(connection: ssl.SSLSocket, protocol: str) -> None:
 
 def validate_certificate(cert: x509.Certificate,
                          sni_domain: str,
+                         peer_chain: list | None=None,
                          name_validation: str | None=None,
                          ca_trust: str | None=None,
                          system_ca_trust: bool=False) -> list:
@@ -294,6 +315,8 @@ def validate_certificate(cert: x509.Certificate,
     :type cert: x509.Certificate
     :param sni_domain: Server hostname.
     :type sni_domain: str
+    :param peer_chain: Intermediate certificates from the TLS handshake.
+    :type peer_chain: list, optional
     :param name_validation: Method how to validate the server hostname (CN, CN/SAN)
     :type name_validation: str, optional
     :param ca_trust: File of trusted CA certs in PEM format.
@@ -317,6 +340,7 @@ def validate_certificate(cert: x509.Certificate,
     # Channel 13 (3): Root Authority Trusted
     # 0 - trusted, 1 - not trusted
     _check_value = validate_certificate_path(cert, sni_domain,
+                                             peer_chain=peer_chain,
                                              ca_trust=ca_trust,
                                              system_ca_trust=system_ca_trust)
     channels.append({
@@ -542,14 +566,20 @@ def validate_certificate_common_name(cert: x509.Certificate,
 
 def validate_certificate_path(cert: x509.Certificate,
                               sni_hostname: str,
+                              peer_chain: list | None=None,
                               ca_trust: str | None=None,
                               system_ca_trust: bool=False) -> int:
     """Validates the path of a certificate
+
+    Uses the intermediate certificates sent by the server during the TLS handshake
+    (peer_chain) to build the certificate chain from leaf to a trusted root CA.
 
     :param cert: The certificate to validate.
     :type cert: x509.Certificate
     :param sni_hostname: SNI hostname
     :type sni_hostname: str
+    :param peer_chain: Intermediate certificates from the TLS handshake.
+    :type peer_chain: list, optional
     :param ca_trust: Path to file of trusted intermediate CA certificates in PEM format, default: None
     :type ca_trust: str, optional
     :param system_ca_trust: Use the CA certificates of the system's certificate store.
@@ -559,13 +589,17 @@ def validate_certificate_path(cert: x509.Certificate,
     """
 
     validation_result = 1
-    intermediate_ca_certs = []
+    # Start with intermediates from the TLS handshake (server-provided chain)
+    intermediate_ca_certs = list(peer_chain) if peer_chain else []
 
     if system_ca_trust:
         root_ca_certs = load_system_ca_trust_certificates()
     else:
         root_ca_certs = load_ca_trust_certificates()
-        intermediate_ca_certs = load_ca_trust_certificates(ca_trust_file=ca_trust)
+        # Extend with user-provided CA trust file if specified
+        if ca_trust:
+            intermediate_ca_certs.extend(
+                load_ca_trust_certificates(ca_trust_file=ca_trust))
     root_ca_store = x509.verification.Store(root_ca_certs)
 
     _verification_time = datetime.datetime.now(datetime.timezone.utc)

--- a/Custom Sensors/scripts/starttls_certificate.py
+++ b/Custom Sensors/scripts/starttls_certificate.py
@@ -32,7 +32,7 @@ import ssl
 import sys
 import certifi
 from cryptography import x509
-from cryptography.x509.oid import ExtensionOID
+from cryptography.x509.oid import ExtensionOID, NameOID
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import rsa
 
@@ -400,7 +400,7 @@ def load_ca_trust_certificates(ca_trust_file: str | None=None) -> list:
             pass
     sys.stderr = _stderr
     return ca_certs
-          
+
 def load_system_ca_trust_certificates() -> list:
     """Loads trusted CA certs from the system's CA trust store.
 
@@ -432,7 +432,7 @@ def load_system_ca_trust_certificates() -> list:
             pass
     sys.stderr = _stderr
     return ca_certs
-          
+
 def read_x509_certificate_san_extension_dnsnames(cert: x509.Certificate) -> list:
     """Reads the DNSName values of the cert's subjectAltName extension.
 
@@ -462,11 +462,10 @@ def read_x509_certificate_common_name(cert: x509.Certificate) -> str:
     :rtype: str
     """
 
-    common_name = list(filter(
-        lambda x: 'cn=' in x.lower().strip(),
-        cert.subject.rfc4514_string().split(',')
-    ))[0].split('=')[1].lower().strip()
-    return common_name
+    cn_attributes = cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME)
+    if cn_attributes:
+        return cn_attributes[0].value.lower().strip()
+    return ''
 
 def read_x509_certificate_fingerprint(cert: x509.Certificate) -> str:
     """Reads the certificate's SHA1 fingerprint.
@@ -476,7 +475,7 @@ def read_x509_certificate_fingerprint(cert: x509.Certificate) -> str:
     :return: The certificate's SHA1 fingerprint in all caps letters.
     :rtype: str
     """
-    
+
     fingerprint = cert.fingerprint(hashes.SHA1()).hex().upper()
     return fingerprint
 

--- a/Custom Sensors/scripts/starttls_certificate.py
+++ b/Custom Sensors/scripts/starttls_certificate.py
@@ -503,6 +503,36 @@ def read_x509_certificate_fingerprint(cert: x509.Certificate) -> str:
     fingerprint = cert.fingerprint(hashes.SHA1()).hex().upper()
     return fingerprint
 
+def match_hostname_wildcard(pattern: str, hostname: str) -> bool:
+    """Checks if a hostname matches a certificate name pattern, supporting wildcards.
+
+    Supports RFC 6125 wildcard matching: a single '*' in the leftmost label
+    matches exactly one label level (e.g. '*.example.com' matches
+    'mx.example.com' but not 'a.b.example.com').
+
+    :param pattern: Certificate CN or SAN value (e.g. '*.example.com').
+    :type pattern: str
+    :param hostname: The hostname to check against the pattern.
+    :type hostname: str
+    :return: True if the hostname matches the pattern.
+    :rtype: bool
+    """
+
+    pattern = pattern.lower().strip()
+    hostname = hostname.lower().strip()
+    if pattern == hostname:
+        return True
+    # Wildcard matching: only a leading '*.' is supported and it matches exactly one label
+    if pattern.startswith('*.') and pattern.count('*') == 1:
+        # The wildcard suffix (e.g. '.example.com')
+        wildcard_suffix = pattern[1:]  # e.g. '.example.com'
+        # hostname must end with the suffix and the part before must be a single label (no dots)
+        if hostname.endswith(wildcard_suffix):
+            prefix = hostname[:-len(wildcard_suffix)]
+            if prefix and '.' not in prefix:
+                return True
+    return False
+
 def validate_certificate_public_key_length(cert: x509.Certificate) -> tuple[int, str]:
     """Validates the public key length of the certificate.
 
@@ -551,14 +581,15 @@ def validate_certificate_common_name(cert: x509.Certificate,
 
     match validation_method:
         case 'CN':
-            if common_name == sni_domain:
+            if match_hostname_wildcard(common_name, sni_domain):
                 check_result = 0
             else:
                 check_result = 1
         case 'CN/SAN':
-            # CN/SAN validation
+            # CN/SAN validation (supports wildcard certificates)
             dns_names = read_x509_certificate_san_extension_dnsnames(cert)
-            if common_name == sni_domain or sni_domain in dns_names:
+            if match_hostname_wildcard(common_name, sni_domain) or \
+                    any(match_hostname_wildcard(san, sni_domain) for san in dns_names):
                 check_result = 5
             else:
                 check_result = 6


### PR DESCRIPTION
Problem: read_x509_certificate_common_name() crashed with IndexError on certificates without a CN in the subject (e.g. modern AD certs using only SANs). The old code parsed the RFC 4514 string by splitting on , and filtering for cn= - empty list → [0] crash.

Fix: Replaced fragile string parsing with cert.subject.get_attributes_for_oid(NameOID.COMMON_NAME). Returns empty string when no CN exists, keeping the function's responsibility clear.

Tested against: Active Directory LDAP (STARTTLS port 389) with a cert lacking a CN attribute.